### PR TITLE
feat: Highlight EP Roads in music section

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
             <div class="releases">
                 <!-- Latest Releases -->
-                <div class="release-card featured">
+                <div class="release-card">
                     <div class="release-year">2025</div>
                     <div class="release-info">
                         <h3>Blazing Star</h3>
@@ -137,7 +137,7 @@
                     </div>
                 </div>
 
-                <div class="release-card">
+                <div class="release-card featured">
                     <div class="release-year">2024</div>
                     <div class="release-info">
                         <h3>Roads</h3>


### PR DESCRIPTION
Instead of highlighting individual singles (Trip, Side, White), the EP Roads is now featured as the highlighted release in the music section with the featured styling.

Fixes #3

—
Generated with [Claude Code](https://claude.ai/code)