### PR TITLE
Add album/EP/single cover images to music section

### DIFF
--- a/images/covers/README.md
+++ b/images/covers/README.md
@@ -1,0 +1,24 @@
+# Album/EP/Single Covers
+
+This directory contains the cover images for all releases displayed in the music section.
+
+## Required Images
+
+Please add the following cover images (JPG format recommended):
+
+- `blazing-star.jpg` - Cover for "Blazing Star" (2025 Single)
+- `gold.jpg` - Cover for "Gold" (2025 Single)
+- `roads.jpg` - Cover for "Roads" (2024 EP)
+- `trip.jpg` - Cover for "Trip" (2024 Single)
+- `white.jpg` - Cover for "White" (2024 Single)
+- `side.jpg` - Cover for "Side" (2024 Single)
+
+## Image Specifications
+
+- Format: JPG or PNG
+- Recommended size: 1000x1000px (square, 1:1 aspect ratio)
+- Maximum file size: Keep under 500KB for optimal performance
+
+## Note
+
+The images will be displayed as square covers in the release cards with rounded corners and shadow effects.

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
             <div class="releases">
                 <!-- Latest Releases -->
                 <div class="release-card featured">
+                    <img src="images/covers/blazing-star.jpg" alt="Blazing Star cover" class="release-cover">
                     <div class="release-year">2025</div>
                     <div class="release-info">
                         <h3>Blazing Star</h3>
@@ -122,6 +123,7 @@
                 </div>
 
                 <div class="release-card">
+                    <img src="images/covers/gold.jpg" alt="Gold cover" class="release-cover">
                     <div class="release-year">2025</div>
                     <div class="release-info">
                         <h3>Gold</h3>
@@ -138,6 +140,7 @@
                 </div>
 
                 <div class="release-card">
+                    <img src="images/covers/roads.jpg" alt="Roads EP cover" class="release-cover">
                     <div class="release-year">2024</div>
                     <div class="release-info">
                         <h3>Roads</h3>
@@ -154,6 +157,7 @@
                 </div>
 
                 <div class="release-card">
+                    <img src="images/covers/trip.jpg" alt="Trip cover" class="release-cover">
                     <div class="release-year">2024</div>
                     <div class="release-info">
                         <h3>Trip</h3>
@@ -170,6 +174,7 @@
                 </div>
 
                 <div class="release-card">
+                    <img src="images/covers/white.jpg" alt="White cover" class="release-cover">
                     <div class="release-year">2024</div>
                     <div class="release-info">
                         <h3>White</h3>
@@ -187,6 +192,7 @@
                 </div>
 
                 <div class="release-card">
+                    <img src="images/covers/side.jpg" alt="Side cover" class="release-cover">
                     <div class="release-year">2024</div>
                     <div class="release-info">
                         <h3>Side</h3>

--- a/style.css
+++ b/style.css
@@ -387,6 +387,9 @@ section {
     border: 2px solid transparent;
     position: relative;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
 }
 
 .release-card::before {
@@ -421,6 +424,25 @@ section {
 .release-card.featured .release-type,
 .release-card.featured h3 {
     color: white;
+}
+
+.release-cover {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: 10px;
+    margin-bottom: var(--spacing-sm);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+    transition: var(--transition);
+}
+
+.release-card:hover .release-cover {
+    transform: scale(1.02);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.release-card.featured .release-cover {
+    box-shadow: 0 6px 25px rgba(0, 0, 0, 0.3);
 }
 
 .release-year {


### PR DESCRIPTION
Fixes #4

Added cover image support to the music section for all singles and EPs.

### Changes
- Added `<img>` elements to all 6 release cards
- Updated CSS with `.release-cover` styling for square images with hover effects
- Created `images/covers/` directory with README for image specifications

### Next Steps
Add the actual cover image files to `images/covers/` directory (see README for specs).

Generated with [Claude Code](https://claude.ai/code)