### PR TITLE
Fix Gold release year to 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
                 <div class="release-card">
                     <a href="releases/gold.html" class="release-card-link">
-                        <div class="release-year">2024</div>
+                        <div class="release-year">2025</div>
                         <img src="https://i.scdn.co/image/ab67616d0000b273bab264e63a8bc9b824304423" alt="Gold Cover" class="release-cover" loading="lazy">
                         <div class="release-info">
                             <h3>Gold</h3>

--- a/releases/gold.html
+++ b/releases/gold.html
@@ -39,7 +39,7 @@
                     <img src="https://i.scdn.co/image/ab67616d0000b273bab264e63a8bc9b824304423" alt="Gold Cover" loading="lazy">
                 </div>
                 <div class="release-meta">
-                    <span class="release-year-badge">2024</span>
+                    <span class="release-year-badge">2025</span>
                     <h1>Gold</h1>
                     <p class="release-type-label">Single</p>
                     <p class="release-artist">7 Pillars</p>


### PR DESCRIPTION
Gold was released on January 17, 2025, not 2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)